### PR TITLE
Add hunting project and enable project page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ first_name: Ha
 middle_name: N.
 last_name: Dong
 contact_note: >
-  "One wants all the powers of mind and spirit and sense to be awakened to new alertness and rise to new confidence, 
+  "One wants all the powers of mind and spirit and sense to be awakened to new alertness and rise to new confidence,
   because that is the only way we realized all the possibilities within us." - P. Pouncey, 16th President of Amherst College
 description: > # the ">" symbol means to ignore newlines until "footer_text:"
   A simple, whitespace theme for academics. Based on [*folio](https://github.com/bogoli/-folio) design.
@@ -200,8 +200,6 @@ exclude:
   - _news
   - _includes/news.liquid
   # Projects
-  - _projects 
-  - _pages/projects.md
   # Repo
   - _pages/repositories.md
   - _includes/repository/

--- a/_projects/10_project.md
+++ b/_projects/10_project.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: "The states of hunting"
+description: "Study of visually guided hunting states in mice"
+img: assets/img/12.jpg
+importance: 1
+category: work
+---
+
+Ha Dong
+Mentors: Daniel Pollak, Markus Meister
+
+## Abstract
+
+The nervous system's dynamic internal state fluctuates in response to environmental changes to control behavioral task switches. Investigating this phenomenon during complex tasks like hunting presents opportunities, particularly in replicating naturalistic conditions within laboratory settings while collecting comprehensive data.
+
+## Overview
+
+Our contribution is three-fold:
+
+1. We present a pipeline for experimentation, data collection, and analysis to understand state-like visually guided hunting in mice using a real-time interactive platform that simulates naturalistic hunting scenarios.
+
+{% include figure.liquid path="assets/img/1.jpg" title="Experimental setup placeholder" class="img-fluid rounded z-depth-1" %}
+{: .caption}
+Placeholder for a figure illustrating the experimental setup.
+
+2. We showed that hunting could be modelled as a two-state Markov process from behavioral data, with the predicted state sequences temporally well-aligned with human annotations.
+
+{% include figure.liquid path="assets/img/2.jpg" title="Modeling results placeholder" class="img-fluid rounded z-depth-1" %}
+{: .caption}
+Placeholder for a figure summarizing the modeling results.
+
+3. We found that the prolonged period of approach behavior predicted by the trained Hidden Markov Model happens concurrently with bursts of activity in a number of superior colliculus neural clusters.
+
+{% include figure.liquid path="assets/img/3.jpg" title="Neural activity placeholder" class="img-fluid rounded z-depth-1" %}
+{: .caption}
+Placeholder for a figure showing neural activity related to hunting behavior.
+
+Our study provides a quantitative strategy for researching hunting behavior and highlights how unsupervised state-space models can provide insights into the control of naturalistic behaviors.


### PR DESCRIPTION
## Summary
- enable Jekyll to build project pages
- add a project page describing the *States of Hunting* work

## Testing
- `pre-commit run --files _config.yml _projects/10_project.md`

------
https://chatgpt.com/codex/tasks/task_e_685f6655cd4483238ceeddadf8b32314